### PR TITLE
Newer version of click breaks uncompyle6 installation.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -9,6 +9,8 @@ I created this powershell script to make it easier to explore how the IMVU clien
 
 ## __I still can't make it run what are the other things requried for this?__
 - You need Python 2.7.9 because for what ever reason IMVU still uses python
-- You need the latest uncompyle6 which can be downloaded using pip `python -m pip install uncompyle6`
+- You will need an older version of click to be able to install uncompyle6 which can be downloaded using pip: `C:\Python27\python.exe -m pip install click==7.1.2`
+- You need the latest uncompyle6 which can be downloaded using pip: `C:\Python27\python.exe -m pip install uncompyle6`
+
 
 _Note your python27 folder must be in c:\python27 or nothing will work_


### PR DESCRIPTION
The pip module Click has removed python2.7 support. This causes Uncompyle6 install to fail. To remedy this. You have to download an older version of click. I've updated the Readme instructions on this.  